### PR TITLE
Fixing issues with Enhanced Journal

### DIFF
--- a/modules/QuickEncounter.js
+++ b/modules/QuickEncounter.js
@@ -401,7 +401,7 @@ export class QuickEncounter {
         //0.7.0b: Capture controlled tiles (will be one or the other
         const controlledTiles = Array.from(Tile.layer.controlled);
 
-        const candidateJournalEntry = QuickEncounter.findCandidateJournalEntry();
+        const candidateJournalEntry = QuickEncounter.findCandidateJournalEntry.call(this); 
         const quickEncounter = (candidateJournalEntry instanceof QuickEncounter ) ? candidateJournalEntry : null;
 
         //v0.6.1 If you have both controlledNonFriendly tokens AND an open Quick Encounter, ask if you want to add to it
@@ -708,7 +708,10 @@ export class QuickEncounter {
         if (Object.keys(ui.windows).length === 0) {return null;}
         else {
             let openJournalSheet = null;
-            for (let w of Object.values(ui.windows)) {
+            for (let w of (this instanceof JournalSheet ? [this] : Object.values(ui.windows))) {
+				//Check to see if this is an Enhanced Journal window and get the subsheet
+				if(w.subsheet)
+					w = w.subsheet;
                 //Check open windows for a Journal Sheet with a Map Note and embedded Actors
                 if (w instanceof JournalSheet) {
                     openJournalSheet = w;
@@ -1517,3 +1520,7 @@ Hooks.on('getSceneControlButtons', QuickEncounter.getSceneControlButtons);
 Hooks.on("deleteCombat", (combat, options, userId) => {
     QuickEncounter.onDeleteCombat(combat, options, userId);
 });
+
+Hooks.on("activateControls", (journal, controls) => {
+	controls.push({ id: 'quickencounter', text: "Quick Encounter", icon: 'fa-fist-raised', conditional: game.user.isGM, callback: QuickEncounter.runAddOrCreate.bind(journal?.subsheet) });
+});												 


### PR DESCRIPTION
Looks like the code changed when selecting a viable entity.
Instead of allowing a Journal Entry it's now looking for a QuickEncounter type to be returned.
Hopefully the changes make sense.
Also note that at the very bottom I had to change it from passing an object to passing the subsheet instead.